### PR TITLE
TestCase implements "standard test interface"

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -45,89 +45,12 @@ final class Command
         $testResult = new TestResult();
 
         foreach ($testClassNames as $testClassName) {
-            // Fixme count test case automatically
-            $testResult->incrementTestsCount();
-
-            // Collect test methods
-            $testClassRef = new ReflectionClass($testClassName);
-            $testMethods = array_filter(
-                array_column($testClassRef->getMethods(\ReflectionMethod::IS_PUBLIC), 'name'),
-                function ($methodName) {
-                    return 'test' === substr($methodName, 0, 4);
-                }
-            );
-
-            // Execute test methods
-            foreach ($testMethods as $testMethod) {
-                    // Search doc comment and provider
-                    $refTestMethod = $testClassRef->getMethod($testMethod);
-                    $docComment = $refTestMethod->getDocComment();
-                if ($docComment &&
-                        preg_match_all(self::REGEX_DATA_PROVIDER, $docComment, $matches)
-                        /**
-                         * ..array(2) {
-                         *   [0]=>
-                         *   array(1) {
-                         *     [0]=>
-                         *     string(30) "@dataProvider providerFizzBuzz"
-                         *   }
-                         *   [1]=>
-                         *     array(1) {
-                         *     [0]=>
-                         *     string(16) "providerFizzBuzz"
-                         *   }
-                         * }
-                         * ....
-                         */
-                    ) {
-                    $providerFunc = $matches[1][0];
-                    $providedArgs = (new $testClassName())->$providerFunc();
-                } else {
-                    $providedArgs = [];
-                }
-
-                if (count($providedArgs) !== 0) {
-                    foreach ($providedArgs as $args) {
-                        $testResult = $this->doRunTest($testClassName, $testMethod, $args, $testResult);
-                    }
-                } else {
-                    $testResult = $this->doRunTest($testClassName, $testMethod, $providedArgs, $testResult);
-                }
-            }
+            /** @var Test $testCase */
+            $testCase = new $testClassName();
+            $testResult = $testCase->run($testResult);
         }
 
         echo PHP_EOL . PHP_EOL;
         return $testResult->endTest();
-    }
-
-    /**
-     * @param $testClassName
-     * @param $testMethod
-     * @param $args
-     * @param TestResult $testResult
-     * @return TestResult
-     */
-    private function doRunTest($testClassName, $testMethod, $args, TestResult $testResult): TestResult
-    {
-        try {
-            /** @var TestCase $sut */
-            $sut = new $testClassName();
-            $sut->setUp();
-            $sut->$testMethod(...$args);
-            $sut->tearDown();
-            $testResult->addPass(new Pass());
-            echo '.';
-        } catch (\AssertionError $e) {
-            $testResult->addFailure(
-                new Failure(
-                    $testClassName,
-                    $testMethod,
-                    $e->getMessage(),
-                    $e->getTraceAsString()
-                )
-            );
-            echo 'F';
-        }
-        return $testResult;
     }
 }

--- a/src/Test.php
+++ b/src/Test.php
@@ -1,0 +1,23 @@
+<?php
+declare(strict_types=1);
+
+namespace MPUnit;
+
+use Countable;
+
+/**
+ * Interface Test
+ *
+ * As a xUnit family, this "standard test interface" should provide a method to count tests.
+ * @package MPUnit
+ */
+interface Test extends Countable
+{
+    /**
+     * Runs method provides interfaces to run test methods.
+     *
+     * @param TestResult $result
+     * @return TestResult
+     */
+    public function run(TestResult $result): TestResult;
+}

--- a/src/TestCase.php
+++ b/src/TestCase.php
@@ -3,14 +3,81 @@
 
 namespace MPUnit;
 
+use ReflectionClass;
+use ReflectionMethod;
+
 /**
  * Class TestCase
  *
  * @package MPUnit
  */
-abstract class TestCase
+abstract class TestCase implements Test
 {
     use Assert;
+
+    private const REGEX_DATA_PROVIDER = '/@dataProvider\s+([a-zA-Z0-9._:-\\\\x7f-\xff]+)/';
+
+    /**
+     * @param TestResult $result
+     * @return TestResult
+     * @throws \ReflectionException
+     */
+    public function run(TestResult $result): TestResult
+    {
+        $class = get_called_class();
+        $classRef = new ReflectionClass($class);
+        $testMethods = array_filter(
+            array_column($classRef->getMethods(ReflectionMethod::IS_PUBLIC), 'name'),
+            function ($methodName) {
+                return 'test' === substr($methodName, 0, 4);
+            }
+        );
+
+        foreach ($testMethods as $testMethod) {
+            // Fixme support provider function in other classes
+            $methodRef = $classRef->getMethod($testMethod);
+            $methodDoc = $methodRef->getDocComment();
+            if ($methodDoc &&
+                preg_match_all(self::REGEX_DATA_PROVIDER, $methodDoc, $matches)
+                /**
+                 * ..array(2) {
+                 *   [0]=>
+                 *   array(1) {
+                 *     [0]=>
+                 *     string(30) "@dataProvider providerFizzBuzz"
+                 *   }
+                 *   [1]=>
+                 *     array(1) {
+                 *     [0]=>
+                 *     string(16) "providerFizzBuzz"
+                 *   }
+                 * }
+                 * ....
+                 */
+            ) {
+                $providerFunc = $matches[1][0];
+                $providedArgs = $this->$providerFunc();
+            } else {
+                $providedArgs = [[]]; // one element
+            }
+
+            foreach ($providedArgs as $args) {
+                $result = $this->doRunTest($testMethod, $args, $result);
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * TestCase object count
+     *
+     * @return int
+     */
+    public function count()
+    {
+        return 1;
+    }
 
     /**
      * @fixme make protected
@@ -26,5 +93,41 @@ abstract class TestCase
     public function tearDown(): void
     {
         // Implement if you needed
+    }
+
+    /**
+     * @param $testClassName
+     * @param $testMethod
+     * @param $args
+     * @param TestResult $testResult
+     * @return TestResult
+     */
+    private function doRunTest($testMethod, $args, TestResult $testResult): TestResult
+    {
+        $testResult->incrementTestsCount();
+
+        $className = get_called_class();
+        try {
+            /** @var TestCase $testClass */
+            $testClass = new $className();
+            $testClass->setUp();
+            $testClass->$testMethod(...$args);
+            $testClass->tearDown();
+            $testResult->addPass(new Pass());
+            // Fixme print stdout outside TestCase
+            echo '.';
+        } catch (\AssertionError $e) {
+            $testResult->addFailure(
+                new Failure(
+                    $className,
+                    $testMethod,
+                    $e->getMessage(),
+                    $e->getTraceAsString()
+                )
+            );
+            // Fixme print stdout outside TestCase
+            echo 'F';
+        }
+        return $testResult;
     }
 }


### PR DESCRIPTION
# TestSuite and TestCase

Command pattern

```
/**
 * A Test can be run and collect its results.
 */
interface Test extends Countable
{
    /**
     * Runs a test and collects its result in a TestResult instance.
     */
    public function run(TestResult $result = null): TestResult;
}
```

Test interfaceを実装している、また Countable interface も実装している
このrun() に対しては、TestRunnerのみが依存している